### PR TITLE
#162982123 An admin user can add tags to a meetup record

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,7 @@ Questioner is a web app that enables users to create meetups and post questions 
  3. Admin can login
  4. User can reset password
  5. User can set new password
+ 6. User can create a new meetup (title + details)
 
 ## Getting Started
 

--- a/createmeetup.html
+++ b/createmeetup.html
@@ -36,9 +36,11 @@
         <input type="text" name="meetuptitle" value="" placeholder="Enter New Meetup Title">
         <label for="meetupdetails">Enter Your Meetup Details here: </label><br><br>
         <textarea name="meetupdetails" rows="20" cols="80" placeholder="Enter your meetup details in here"></textarea>
+        <label for="meetuptags">Add Tags To Your New Meetup i.e <small>farming, irrigation, fertilizers</small></label><br><br>
+        <input type="text" name="meetuptags" id="meetuptags" placeholder="Please Enter your comma seperated tags">
         <input type="submit" value="Create Meetup">
       </form>
-      
+
     </div>
 
 


### PR DESCRIPTION
**What does this PR do?**
This will add a tags input field below the details text area field in the `createmeetup.html` file enabling the admin to add tags to the new meetup.

**Description of Task to be completed?**
- Update the createmeeetup form.
- Add text input field to the create meetup page for tags.
- Style the meetup page form.

**How should this be manually tested?**
- git clone this repo
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- Open the `createmeetup.html` file in your preferred browser.

**What are the relevant pivotal tracker stories?**
#162982123

Screenshots

![screenshot_2019-01-07 admin - create new questioner meetup](https://user-images.githubusercontent.com/21017945/50741879-a2b61a80-1214-11e9-92bd-e22241bc0e76.png)
![screenshot_2019-01-07 admin - create new questioner meetup 1](https://user-images.githubusercontent.com/21017945/50741880-a2b61a80-1214-11e9-876d-6e165a4adfd0.png)
![screenshot_2019-01-07 admin - create new questioner meetup 2](https://user-images.githubusercontent.com/21017945/50741881-a34eb100-1214-11e9-9baa-1457852e9189.png)
