### PR TITLE
#162980019 An admin user can add images to a meetup record

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,7 +7,7 @@ Questioner is a web app that enables users to create meetups and post questions 
  3. Admin can login
  4. User can reset password
  5. User can set new password
- 6. User can create a new meetup (title + details)
+ 6. User can create a new meetup (title + details + tags)
 
 ## Getting Started
 

--- a/createmeetup.html
+++ b/createmeetup.html
@@ -38,6 +38,10 @@
         <textarea name="meetupdetails" rows="20" cols="80" placeholder="Enter your meetup details in here"></textarea>
         <label for="meetuptags">Add Tags To Your New Meetup i.e <small>farming, irrigation, fertilizers</small></label><br><br>
         <input type="text" name="meetuptags" id="meetuptags" placeholder="Please Enter your comma seperated tags">
+        <label for="imageone">Select Image(optional)</label><br><br>
+        <input type="file" name="imageone" id="imageone"><br><br>
+        <label for="imagetwo">Select Image2(optional)</label><br><br>
+        <input type="file" name="imagetwo" id="imagetwo"><br><br>
         <input type="submit" value="Create Meetup">
       </form>
 


### PR DESCRIPTION
**What does this PR do?**
This will update the `createmeetup.html` page adding two file input boxes enabling the admin user to add a maximum of two images when creating a new meetup.

**Description of Task to be completed?**
- Update the create meetup html form.
- Add two file input fields.
- Style the meetup page form.

**How should this be manually tested?**
- git clone this repo
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- open the `createmeetup.html` file in your preferred browser.

**What are the relevant pivotal tracker stories?**
#162980019

Screenshots

![screenshot_2019-01-07 admin - create new questioner meetup](https://user-images.githubusercontent.com/21017945/50742094-b4e58800-1217-11e9-93b6-7e1277b9f68d.png)
![screenshot_2019-01-07 admin - create new questioner meetup 1](https://user-images.githubusercontent.com/21017945/50742095-b57e1e80-1217-11e9-9184-094f227375ea.png)
![screenshot_2019-01-07 admin - create new questioner meetup 2](https://user-images.githubusercontent.com/21017945/50742096-b57e1e80-1217-11e9-8ac3-49a6f044e6bc.png)
