### PR TITLE
#162989980 A user can view top questions from upcoming meetups

### DIFF
--- a/accountprofile.html
+++ b/accountprofile.html
@@ -53,6 +53,23 @@
           </div>
         </div>
         <div class="classyrule"></div>
+        <div class="upcomingmeetupsprof">
+          <h3>Top Questions from Upcoming Meetups</h3>
+          <ul class="meetupqustns">
+            <li><a href="#">Should we carry ID's? - Mombasa Meetup</a></li>
+            <li><a href="#">Are newcomers welcome? - Farmers Union Meetup</a></li>
+            <li><a href="#">Is it a child friendly environment? - Playdates Meetup</a></li>
+
+            <li><a href="#">Should we carry ID's? - Mombasa Meetup</a></li>
+            <li><a href="#">Are newcomers welcome? - Farmers Union Meetup</a></li>
+            <li><a href="#">Is it a child friendly environment? - Playdates Meetup</a></li>
+
+            <li><a href="#">Should we carry ID's? - Mombasa Meetup</a></li>
+            <li><a href="#">Are newcomers welcome? - Farmers Union Meetup</a></li>
+            <li><a href="#">Is it a child friendly environment? - Playdates Meetup</a></li>
+            
+          </ul>
+        </div>
 
     </div>
     <div class="indxfooter">

--- a/accountprofile.html
+++ b/accountprofile.html
@@ -55,7 +55,7 @@
         <div class="classyrule"></div>
         <div class="upcomingmeetupsprof">
           <h3>Top Questions from Upcoming Meetups</h3>
-          <ul class="meetupqustns">
+          <ol class="meetupqustns">
             <li><a href="#">Should we carry ID's? - Mombasa Meetup</a></li>
             <li><a href="#">Are newcomers welcome? - Farmers Union Meetup</a></li>
             <li><a href="#">Is it a child friendly environment? - Playdates Meetup</a></li>
@@ -67,8 +67,8 @@
             <li><a href="#">Should we carry ID's? - Mombasa Meetup</a></li>
             <li><a href="#">Are newcomers welcome? - Farmers Union Meetup</a></li>
             <li><a href="#">Is it a child friendly environment? - Playdates Meetup</a></li>
-            
-          </ul>
+
+          </ol>
         </div>
 
     </div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -474,7 +474,7 @@ li.indxuserbtnsscrtmet{
 	background-image: url('../images/doodle.jpg');
 	background-size: 30%;
 	background-repeat: repeat;
-	height: 100vh;
+	min-height: 100vh;
 	margin: 0;
 	padding: 0;
 }
@@ -482,7 +482,8 @@ li.indxuserbtnsscrtmet{
 	background-color: white;
 	width: 60%;
 	margin: 0 auto;
-	height: 90vh;
+	height: auto;
+	min-height: 90vh;
 }
 .overlder{
 	width: 100%;
@@ -529,5 +530,19 @@ li.indxuserbtnsscrtmet{
 	margin: 0;
 	color: rgba(40, 40, 40, 0.65);
 }
-
+.upcomingmeetupsprof h3{
+	text-align: center;
+}
+.upcomingmeetupsprof{
+	height: 500px;
+	width: 100%;
+	background-color: gainsboro;
+	padding-top: 10px;
+}
+.meetupqustns li{
+	margin: 3px auto;
+}
+.meetupqustns li a{
+	text-decoration: none;
+}
 /* ACCOUNT PROFILE PAGE */

--- a/static/css/mediumscreen.css
+++ b/static/css/mediumscreen.css
@@ -475,7 +475,8 @@ li.indxuserbtnsscrtmet{
 	background-color: white;
 	width: 60%;
 	margin: 0 auto;
-	height: 90vh;
+	min-height: 90vh;
+	height: auto;
 }
 .overlder{
 	width: 100%;
@@ -521,5 +522,20 @@ li.indxuserbtnsscrtmet{
 	padding: 0;
 	margin: 0;
 	color: rgba(40, 40, 40, 0.65);
+}
+.upcomingmeetupsprof h3{
+	text-align: center;
+}
+.upcomingmeetupsprof{
+	height: 500px;
+	width: 100%;
+	background-color: gainsboro;
+	padding-top: 10px;
+}
+.meetupqustns li{
+	margin: 3px auto;
+}
+.meetupqustns li a{
+	text-decoration: none;
 }
 /* ACCOUNT PROFILE PAGE */

--- a/static/css/smallscreen.css
+++ b/static/css/smallscreen.css
@@ -464,7 +464,8 @@ li.indxuserbtnsscrtmet{
 	background-color: white;
 	width: 60%;
 	margin: 0 auto;
-	height: 90vh;
+	min-height: 90vh;
+	height: auto;
 }
 .overlder{
 	width: 100%;
@@ -510,5 +511,20 @@ li.indxuserbtnsscrtmet{
 	padding: 0;
 	margin: 0;
 	color: rgba(40, 40, 40, 0.65);
+}
+..upcomingmeetupsprof h3{
+	text-align: center;
+}
+.upcomingmeetupsprof{
+	height: 500px;
+	width: 100%;
+	background-color: gainsboro;
+	padding-top: 10px;
+}
+.meetupqustns li{
+	margin: 3px auto;
+}
+.meetupqustns li a{
+	text-decoration: none;
 }
 /* ACCOUNT PROFILE PAGE */


### PR DESCRIPTION

**What does this PR do?**
This will update the `account profile` html page adding a new panel where a user can now see a feed of the top questions in upcoming meetups.

Screenshots
**Description of Task to be completed?**
- update the account profile page to show the top questions feed for upcoming meetups

**How should this be manually tested?**
- git clone this repo
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- Open the `accountprofile` html page in a browser of your choice.

**What are the relevant pivotal tracker stories?**
#1629899804

![screenshot_2019-01-07 questioner home](https://user-images.githubusercontent.com/21017945/50756573-afb32800-126d-11e9-8340-19cf540acf33.png)
![screenshot_2019-01-07 questioner home 1](https://user-images.githubusercontent.com/21017945/50756576-afb32800-126d-11e9-87ab-9050c69cd79c.png)
![screenshot_2019-01-07 questioner home 2](https://user-images.githubusercontent.com/21017945/50756577-afb32800-126d-11e9-9f24-4cb85af38123.png)

