### PR TITLE
#163073886 Setup Failing Test for get-specific-meetup endpoint

### DIFF
--- a/app/tests/v1/test_user.py
+++ b/app/tests/v1/test_user.py
@@ -11,6 +11,9 @@ class TestUserEndpoints(unittest.TestCase):
 		self.response_message = self.client.get('/api/v1/meetups/upcoming')
 		self.assertEqual(self.response_message.status_code, 200)
 
+	def test_getspecificmeetup(self):
+		assertEqual(2,34)
+
 
 	def tearDown(self):
 		self.app = None


### PR DESCRIPTION
**What does this PR do?**
Setup a failing test for `get a specific meetup record` endpoint. This ensures that our development sticks to a TDD approach by first ensuring that the test fails by intentionally making it fail.

**Description of Task to be completed?**
- create a test that fails for the `get a specific meetup record` end point

**How should this be manually tested?**
- git clone this repo 
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- switch into the develop branch
> $ git checkout develop
- Create a virtual enviroment
> $ virtualenv env
- Activate the virual environment
> $ source env/bin/activate
- Install the requirements by running
> $ pip install -r requirements.txt
- run the server 
> $ export FLASK_APP=run.py
> $ export FLASK_ENV=development
> $ flask run
- run pytest on the `test_user.py` file located in the `app/tests/v1/` directory
- one test should fail.

**What are the relevant pivotal tracker stories?**
#163073886

Screenshots

![screenshot_2019-01-09_06-23-43](https://user-images.githubusercontent.com/21017945/50875278-b4e0b600-13d8-11e9-93e1-42e3148e095b.png)
