### PR TITLE
#163106932 Patch bugs on the failing test for the upvote api endpoint

### DIFF
--- a/app/tests/v1/test_adminuser.py
+++ b/app/tests/v1/test_adminuser.py
@@ -31,8 +31,6 @@ class TestAdminEndpoints(unittest.TestCase):
 		self.response_message = self.client.post('api/v1/meetups',
 			data=json.dumps(DataStrctPayloads.meetup_longer_payload()), content_type="application/json")
 		self.assertEqual(self.response_message.status_code, 400)
-
-	def test_upvotequestion(self):
 		
 
 

--- a/app/tests/v1/test_user.py
+++ b/app/tests/v1/test_user.py
@@ -48,6 +48,9 @@ class TestUserEndpoints(unittest.TestCase):
 			data=json.dumps(DataStrctPayloads.longer_question_payload), content_type="application/json")
 		self.assertEqual(self.response_message.status_code, 400)
 
+	def test_upvotequestion(self):
+	
+
 
 
 


### PR DESCRIPTION
**What does this PR do?**
This will recreate and rerun the first failed test for the upvote endpoint fixing the bug that initially allowed the first test to fail as was expected but would end up skewing the data being that it was already in the wrong test class.
**Description of Task to be completed?**
- redo the failing upvote api endpoint test in the proper class

**How should this be manually tested?**
- git clone this repo 
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- switch into the develop branch
> $ git checkout develop
- Create a virtual enviroment
> $ virtualenv env
- Activate the virual environment
> $ source env/bin/activate
- Install the requirements by running
> $ pip install -r requirements.txt
- run the server 
> $ export FLASK_APP=run.py
> $ export FLASK_ENV=development
> $ flask run
- run pytest
> $ pytest

**What are the relevant pivotal tracker stories?**
#163106932

Screenshots
Before
![download](https://user-images.githubusercontent.com/21017945/50938845-28db9680-148b-11e9-9ce9-b897347a51cb.png)

after the bug fix
![screenshot_2019-01-10_02-53-45](https://user-images.githubusercontent.com/21017945/50938849-2f6a0e00-148b-11e9-8bec-5dc2ec60605f.png)
