### PR TITLE
#163161870 Fix reserve meetup bug

### DIFF
--- a/app/api/v1/views/user_views.py
+++ b/app/api/v1/views/user_views.py
@@ -107,8 +107,14 @@ class ShowallRsvps(Resource):
 	def get(self):
 		return rsvpCntr.showall_rsvps()
 
-@UserApi.route('/api/v1/meetups/<meetupid>/rsvps')
+@UserApi.route('/api/v1/meetups/<int:meetupid>/rsvps')
 class createMeetupRsvp(Resource):
 	def post(self, meetupid):
 		reservationMaking = request.get_json()
-		return rsvpCntr.add_rsvp(meetupid,reservationMaking)
+		if reservationMaking:
+			return rsvpCntr.add_rsvp(meetupid,reservationMaking)
+		else:
+			return {
+				"status" : 400,
+				"error" : "You did not provide any input"
+				}, 400

--- a/app/tests/v1/test_user.py
+++ b/app/tests/v1/test_user.py
@@ -72,10 +72,6 @@ class TestUserEndpoints(unittest.TestCase):
 		self.response_message = self.client.put('/api/v1/questions/100000/downvote')
 		self.assertEqual(self.response_message.status_code, 404)
 
-	def test_rsvpMeetupCreate(self):
-		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
-			data=json.dumps(DataStrctPayloads.rvsp_payload()), content_type="application/json")
-		self.assertEqual(self.response_message.status_code, 400)
 
 	def test_rsvpMeetupRetriveAll(self):
 		self.response_message = self.client.get('/api/v1/meetups/rsvps')
@@ -85,6 +81,30 @@ class TestUserEndpoints(unittest.TestCase):
 		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
 			data=json.dumps(''), content_type="application/json")
 		self.assertEqual(self.response_message.status_code, 400)
+
+	def test_RsvpSuccessCreateEmpty(self):
+		"""  run after successfully creating a meetup """
+		self.response_message = self.client.post('/api/v1/meetups',
+			data=json.dumps(DataStrctPayloads.meetuppayload()), content_type="application/json")
+		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
+			data=json.dumps(''), content_type="application/json")
+		self.assertEqual(self.response_message.status_code, 400)
+
+	def test_RsvpCreateGoodRequest(self):
+		"""  run after successfully creating a meetup """
+		self.response_message = self.client.post('/api/v1/meetups',
+			data=json.dumps(DataStrctPayloads.meetuppayload()), content_type="application/json")
+		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
+			data=json.dumps(DataStrctPayloads.rvsp_payload()), content_type="application/json")
+		self.assertEqual(self.response_message.status_code, 201)
+
+	def test_RsvpMultipleCreate(self):
+		"""  Try to create multiple reservations on the same meetup with the same user id """
+		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
+			data=json.dumps(DataStrctPayloads.rvsp_payload()), content_type="application/json")
+		self.response_message = self.client.post('/api/v1/meetups/1/rsvps',
+			data=json.dumps(DataStrctPayloads.rvsp_payload()), content_type="application/json")
+		self.assertEqual(self.response_message.status_code, 409)
 
 
 	def tearDown(self):


### PR DESCRIPTION
**What does this PR do?**
This will fix a certain bug that prevented the user from responding new meetups by sending a string as an Id rather than an ID. Simply changing the variable rule to int solved this.

**Description of Task to be completed?**
- Fix reserve meetup endpoint bug.

**How should this be manually tested?**
- git clone this repo 
> $ git clone https://github.com/wachiranduati/Questioner.git
- cd into it.
> $ cd Questioner
- switch into the develop branch
> $ git checkout develop
- Create a virtual enviroment
> $ virtualenv env
- Activate the virual environment
> $ source env/bin/activate
- Install the requirements by running
> $ pip install -r requirements.txt
- run the server 
> $ export FLASK_APP=run.py
> $ export FLASK_ENV=development
> $ flask run
- run pytest
> $ pytest
- you could also navigate to the endpoint at `/api/v1/meetups/1/rsvps` but remember to first create a meetup with id of 1 in our case at endpoint `/api/v1/meetups` using postman.

**What are the relevant pivotal tracker stories?**
#163161870

Screenshots
![screenshot_2019-01-12_00-49-20](https://user-images.githubusercontent.com/21017945/51063220-12f4df80-160b-11e9-8940-6aacaf98143a.png)
